### PR TITLE
Make bacula user and group configurable

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -9,6 +9,8 @@
 class bacula::common (
   $homedir  = $bacula::params::homedir,
   $packages = $bacula::params::bacula_client_packages,
+  $user     = $bacula::params::bacula_user,
+  $group    = $bacula::params::bacula_group,
 ) inherits bacula::params {
 
   include bacula::ssl
@@ -17,8 +19,8 @@ class bacula::common (
 
   file { $homedir:
     ensure  => directory,
-    owner   => 'bacula',
-    group   => 'bacula',
+    owner   => $user,
+    group   => $group,
     mode    => '0700',
     require => Package[$packages],
   }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -25,6 +25,7 @@ class bacula::director (
   $rundir              = $bacula::params::rundir,
   $conf_dir            = $bacula::params::conf_dir,
   $storage             = $bacula::params::bacula_storage,
+  $group               = $bacula::params::bacula_group,
 ) inherits bacula::params {
 
   include bacula::common
@@ -50,14 +51,14 @@ class bacula::director (
 
   file { "${conf_dir}/bconsole.conf":
     owner   => 'root',
-    group   => 'bacula',
+    group   => $group,
     mode    => '0640',
     content => template('bacula/bconsole.conf.erb');
   }
 
   Concat {
     owner  => 'root',
-    group  => 'bacula',
+    group  => $group,
     mode   => '0640',
     notify => Service[$services],
   }

--- a/manifests/director/database.pp
+++ b/manifests/director/database.pp
@@ -4,6 +4,7 @@ class bacula::director::database(
   $db_pw              = $bacula::director::db_pw,
   $db_user            = $bacula::director::db_user,
   $services           = $bacula::params::bacula_director_services,
+  $user               = $bacula::params::bacula_user,
 ) inherits bacula::params {
 
   require postgresql::server
@@ -16,13 +17,13 @@ class bacula::director::database(
 
   file { $make_bacula_tables:
     content => template('bacula/make_bacula_postgresql_tables.erb'),
-    owner   => 'bacula',
+    owner   => $user,
     mode    => '0750',
     before  => Exec["/bin/sh ${make_bacula_tables}"]
   }
 
   exec { "/bin/sh ${make_bacula_tables}":
-    user        => 'bacula',
+    user        => $user,
     refreshonly => true,
     subscribe   => Postgresql::Server::Db[$db_name],
     notify      => Service[$services],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,6 +38,8 @@ class bacula::params {
       $client_config            = '/etc/bacula/bacula-fd.conf'
       $homedir                  = '/var/lib/bacula'
       $rundir                   = '/var/run/bacula'
+      $bacula_user              = 'bacula'
+      $bacula_group             = $bacula_user
     }
     'centos','fedora','sles': {
       $bacula_director_packages = [ 'bacula-director-common', "bacula-director-${db_type}", 'bacula-console' ]
@@ -51,6 +53,8 @@ class bacula::params {
       $client_config            = '/etc/bacula/bacula-fd.conf'
       $homedir                  = '/var/lib/bacula'
       $rundir                   = '/var/run'
+      $bacula_user              = 'bacula'
+      $bacula_group             = $bacula_user
     }
     'freebsd': {
       $bacula_client_packages = 'sysutils/bacula-client'
@@ -60,6 +64,8 @@ class bacula::params {
       $client_config          = '/usr/local/etc/bacula/bacula-fd.conf'
       $rundir                 = '/var/run'
       $homedir                = '/var/db/bacula'
+      $bacula_user            = 'bacula'
+      $bacula_group           = $bacula_user
     }
     default: { fail("bacula::params has no love for ${::operatingsystem}") }
   }

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -8,6 +8,7 @@ class bacula::ssl (
   $keyfile  = $bacula::params::keyfile,
   $cafile   = $bacula::params::cafile,
   $packages = $bacula::params::bacula_client_packages,
+  $user     = $bacula::params::bacula_user,
 ) inherits bacula::params {
 
   $ssl_files = [
@@ -17,7 +18,7 @@ class bacula::ssl (
   ]
 
   File {
-    owner   => 'bacula',
+    owner   => $user,
     group   => '0',
     mode    => '0640',
     require => Package[$packages],

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -16,6 +16,8 @@ class bacula::storage (
   $rundir                  = $bacula::params::rundir,
   $conf_dir                = $bacula::params::conf_dir,
   $director                = $bacula::params::bacula_director,
+  $user                    = $bacula::params::bacula_user,
+  $group                   = $bacula::params::bacula_group,
   $volret_full             = '21 days',
   $maxvolbytes_full        = '4g',
   $maxvoljobs_full         = '10',
@@ -64,7 +66,7 @@ class bacula::storage (
 
   concat { "${conf_dir}/bacula-sd.conf":
     owner  => 'root',
-    group  => 'bacula',
+    group  => $group,
     mode   => '0640',
     notify => Service[$services],
   }
@@ -72,8 +74,8 @@ class bacula::storage (
   if $media_type == 'File' {
     file { $device:
       ensure => directory,
-      owner  => 'bacula',
-      group  => 'bacula',
+      owner  => $user,
+      group  => $group,
       mode   => '0750',
     }
   }


### PR DESCRIPTION
This is an untested and mechanical change, but no functional change is intended. It will be used later when OpenBSD support is added where the user/group are `_bacula`.
