### PR TITLE
concat::setup is deprecated

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -13,7 +13,6 @@ class bacula::common (
 
   include bacula::ssl
   include bacula::client
-  include concat::setup
 
   file { $homedir:
     ensure  => directory,


### PR DESCRIPTION
```
Warning: Scope(Class[Concat::Setup]): concat::setup is deprecated as a public API of the concat module and should no longer be directly included in the manifest.
```
