### PR TITLE
make Maximum Concurrent Jobs configurable

### DIFF
--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -21,6 +21,7 @@ class bacula::storage (
   $volret_full             = '21 days',
   $maxvolbytes_full        = '4g',
   $maxvoljobs_full         = '10',
+  $maxconcurjobs           = '5',
   $maxvols_full            = '10',
   $volret_incremental      = '8 days',
   $maxvolbytes_incremental = '4g',

--- a/templates/bacula-sd-header.erb
+++ b/templates/bacula-sd-header.erb
@@ -15,6 +15,7 @@ Device {
   AutomaticMount = yes;
   RemovableMedia = no;
   AlwaysOpen     = no;
+  Maximum Concurrent Jobs = <%= @maxconcurjobs %>
 }
 
 # Send all messages to the Director,


### PR DESCRIPTION
This defaults to the upstream default as of 7.0.5.
