### PR TITLE
Allow for using a different database than postgresql.

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -17,6 +17,7 @@ class bacula::director (
   $db_user             = 'bacula',
   $db_pw               = 'notverysecret',
   $db_name             = 'bacula',
+  $db_type             = $bacula::params::db_type,
   $password            = 'secret',
   $max_concurrent_jobs = '20',
   $packages            = $bacula::params::bacula_director_packages,
@@ -31,8 +32,12 @@ class bacula::director (
   include bacula::common
   include bacula::client
   include bacula::ssl
-  include bacula::director::database
   include bacula::director::defaults
+
+  case $db_type {
+    /^(pgsql|postgresql)$/: { include bacula::director::postgresql }
+    default:                { fail("No db_type set") }
+  }
 
   package { $packages:
     ensure => present,

--- a/manifests/director/postgresql.pp
+++ b/manifests/director/postgresql.pp
@@ -1,4 +1,4 @@
-class bacula::director::database(
+class bacula::director::postgresql(
   $make_bacula_tables = '/var/lib/bacula/make_bacula_tables',
   $db_name            = $bacula::director::db_name,
   $db_pw              = $bacula::director::db_pw,


### PR DESCRIPTION
Though currently only the postgresql class is included in this module.

Since `$db_type` can be set to something other than `pgsql` for the sake of the package names, check for both `pgsql` and `postgresql` wether to include the `bacula::director::postgresql` class.

Also, support for mysql and sqlite3 are currently missing.
