### PR TITLE
Make director and storage packages virtual resources

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -33,15 +33,14 @@ class bacula::director (
   include bacula::client
   include bacula::ssl
   include bacula::director::defaults
+  include bacula::virtual
 
   case $db_type {
     /^(pgsql|postgresql)$/: { include bacula::director::postgresql }
     default:                { fail('No db_type set') }
   }
 
-  package { $packages:
-    ensure => present,
-  }
+  realize(Package[$packages])
 
   service { $services:
     ensure    => running,

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -31,10 +31,9 @@ class bacula::storage (
 
   include bacula::common
   include bacula::ssl
+  include bacula::virtual
 
-  package { $packages:
-    ensure => present,
-  }
+  realize(Package[$packages])
 
   service { $services:
     ensure    => running,

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -1,0 +1,17 @@
+# Class: bacula::virtual
+#
+# This class contains virtual resources shared between the bacula::director
+# and bacula::storage classes.
+#
+class bacula::virtual(
+  $director_packages = $bacula::params::bacula_director_packages,
+  $storage_packages  = $bacula::params::storage_director_packages,
+) inherits bacula::params {
+  @package { $director_packages:
+    ensure => present
+  }
+
+  @package { $storage_packages:
+    ensure => present
+  }
+}


### PR DESCRIPTION
On some systems, such as OpenBSD, there is a single package containing
the dir and sd services, which would lead to duplicate resources.
