### PR TITLE
Add support for OpenBSD (dir, sd and fd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A puppet module for the Bacula backup system.
 
 * Linux
   * Debian, Ubuntu, Centos, Fedora, SLES
-* FreeBSD
+* FreeBSD (client only)
+* OpenBSD
 
 # Requirements
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -67,6 +67,21 @@ class bacula::params {
       $bacula_user            = 'bacula'
       $bacula_group           = $bacula_user
     }
+    'openbsd': {
+      $bacula_director_packages = [ 'bacula-server', "bacula-${db_type}" ]
+      $bacula_director_services = [ 'bacula_dir' ]
+      $bacula_storage_packages  = [ 'bacula-server', "bacula-${db_type}" ]
+      $bacula_storage_services  = [ 'bacula_sd' ]
+      $bacula_client_packages   = 'bacula-client'
+      $bacula_client_services   = 'bacula_fd'
+      $conf_dir                 = '/etc/bacula'
+      $bacula_dir               = '/etc/bacula/ssl'
+      $client_config            = '/etc/bacula/bacula-fd.conf'
+      $rundir                   = '/var/run'
+      $homedir                  = '/var/bacula'
+      $bacula_user              = '_bacula'
+      $bacula_group             = '_bacula'
+    }
     default: { fail("bacula::params has no love for ${::operatingsystem}") }
   }
 


### PR DESCRIPTION
Tested on OpenBSD -current with Bacula 7.0.5 in a disk-only setup.
