### PR TITLE
Add support for the RunScript directive in Job definitions

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -13,6 +13,7 @@
 #     else, provided it's a String, that named fileset will be used.
 #     NOTE: the fileset Common or the defined fileset must be declared elsewhere
 #     for this to work. See Class::Bacula for details.
+#   * runscript - Array of hash(es) containing RunScript directives.
 #
 # Actions:
 #   * Exports job fragment for consuption on the director
@@ -32,17 +33,19 @@
 #  }
 #
 define bacula::job (
-  $files    = [],
-  $excludes = [],
-  $jobtype  = 'Backup',
-  $fileset  = true,
-  $template = 'bacula/job.conf.erb',
-  $pool     = 'Default',
-  $jobdef   = 'Default'
+  $files     = [],
+  $excludes  = [],
+  $jobtype   = 'Backup',
+  $fileset   = true,
+  $template  = 'bacula/job.conf.erb',
+  $pool      = 'Default',
+  $jobdef    = 'Default',
+  $runscript = [],
 ) {
   validate_array($files)
   validate_array($excludes)
   validate_re($jobtype, ['^Backup', '^Restore', '^Admin', '^Verify'])
+  validate_array($runscript)
 
   include bacula::common
   include bacula::params

--- a/templates/job.conf.erb
+++ b/templates/job.conf.erb
@@ -14,5 +14,15 @@ Job {
 <% if @jobdef -%>
     JobDefs          = "<%= @jobdef %>"
 <% end -%>
+<% @runscript.each do |script| -%>
+    RunScript {
+      RunsWhen = <%= script.fetch('runs_when') %>
+      FailJobOnError = <%= (script['fail_job_on_error'] != false) ? 'yes' : 'no' %>
+      RunsOnSuccess = <%= (script['runs_on_success'] != false) ? 'yes' : 'no' %>
+      RunsOnFailure = <%= script['runs_on_failure'] ? 'yes' : 'no' %>
+      RunsOnClient = <%= script['runs_on_client'] ? 'yes' : 'no' %>
+      Command = <%= script.fetch('command').inspect %>
+    }
+<% end -%>
 }
 


### PR DESCRIPTION
For example:

``` puppet
bacula::job { 'foo':
  files => ['/bar'],
  runscript => [
    { runs_when      => 'Before',
      runs_on_client => true,
      command        => 'sh -c "/bin/date >> /tmp/date.log"' },
  ]
}
```

This will also allow mere mortals without the enterprise mysql/postgresql plugins for Bacula to dump a database before running the Job that backs up the dump.
