### PR TITLE
sync make_bacula_postgresql_tables with upstream

### DIFF
--- a/templates/make_bacula_postgresql_tables.erb
+++ b/templates/make_bacula_postgresql_tables.erb
@@ -2,9 +2,24 @@
 #
 # shell script to create Bacula PostgreSQL tables
 #
-# Important note:
+# Important note: 
 #   You won't get any support for performance issue if you changed the default
 #   schema.
+#
+#
+#  Bacula(r) - The Network Backup Solution
+#
+#  Copyright (C) 2000-2014 Free Software Foundation Europe e.V.
+#
+#  The main author of Bacula is Kern Sibbald, with contributions from many
+#  others, a complete list can be found in the file AUTHORS.
+#
+#  You may use this file and others of this release according to the
+#  license defined in the LICENSE file, which includes the Affero General
+#  Public License, v3.0 ("AGPLv3") and some additional permissions and
+#  terms pursuant to its AGPLv3 Section 7.
+#
+#  Bacula(r) is a registered trademark of Kern Sibbald.
 #
 bindir=/usr/bin
 PATH="$bindir:$PATH"
@@ -14,8 +29,8 @@ psql -f - -d ${db_name} $* <<END-OF-DATA
 
 CREATE TABLE Filename
 (
-    FilenameId        serial    not null,
-    Name        text    not null,
+    FilenameId	      serial	  not null,
+    Name	      text	  not null,
     primary key (FilenameId)
 );
 
@@ -24,8 +39,8 @@ CREATE UNIQUE INDEX filename_name_idx on Filename (Name);
 
 CREATE TABLE Path
 (
-    PathId        serial    not null,
-    Path        text    not null,
+    PathId	      serial	  not null,
+    Path	      text	  not null,
     primary key (PathId)
 );
 
@@ -36,27 +51,27 @@ CREATE UNIQUE INDEX path_name_idx on Path (Path);
 -- In general, these will cause very significant performance
 -- problems in other areas.  A better approch is to carefully check
 -- that all your memory configuation parameters are
--- suitable for the size of your installation.  If you backup
+-- suitable for the size of your installation.	If you backup
 -- millions of files, you need to adapt the database memory
 -- configuration parameters concerning sorting, joining and global
 -- memory.  By default, sort and join parameters are very small
 -- (sometimes 8Kb), and having sufficient memory specified by those
--- parameters is extremely important to run fast.
+-- parameters is extremely important to run fast.  
 
 -- In File table
 -- FileIndex can be 0 for FT_DELETED files
 -- FileNameId can link to Filename.Name='' for directories
 CREATE TABLE File
 (
-    FileId        bigserial   not null,
-    FileIndex       integer   not null  default 0,
-    JobId       integer   not null,
-    PathId        integer   not null,
-    FilenameId        integer   not null,
-    DeltaSeq        smallint    not null  default 0,
-    MarkId        integer   not null  default 0,
-    LStat       text    not null,
-    Md5         text    not null,
+    FileId	      bigserial   not null,
+    FileIndex	      integer	  not null  default 0,
+    JobId	      integer	  not null,
+    PathId	      integer	  not null,
+    FilenameId	      integer	  not null,
+    DeltaSeq	      smallint	  not null  default 0,
+    MarkId	      integer	  not null  default 0,
+    LStat	      text	  not null,
+    Md5 	      text	  not null,
     primary key (FileId)
 );
 
@@ -95,58 +110,58 @@ CREATE INDEX restore_jobid_idx on RestoreObject(JobId);
 
 CREATE TABLE Job
 (
-    JobId       serial    not null,
-    Job         text    not null,
-    Name        text    not null,
-    Type        char(1)   not null,
-    Level       char(1)   not null,
-    ClientId        integer   default 0,
-    JobStatus       char(1)   not null,
-    SchedTime       timestamp   without time zone,
-    StartTime       timestamp   without time zone,
-    EndTime       timestamp   without time zone,
+    JobId	      serial	  not null,
+    Job 	      text	  not null,
+    Name	      text	  not null,
+    Type	      char(1)	  not null,
+    Level	      char(1)	  not null,
+    ClientId	      integer	  default 0,
+    JobStatus	      char(1)	  not null,
+    SchedTime	      timestamp   without time zone,
+    StartTime	      timestamp   without time zone,
+    EndTime	      timestamp   without time zone,
     RealEndTime       timestamp   without time zone,
-    JobTDate        bigint    default 0,
-    VolSessionId      integer   default 0,
-    volSessionTime    integer   default 0,
-    JobFiles        integer   default 0,
-    JobBytes        bigint    default 0,
-    ReadBytes       bigint    default 0,
-    JobErrors       integer   default 0,
-    JobMissingFiles   integer   default 0,
-    PoolId        integer   default 0,
-    FilesetId       integer   default 0,
-    PriorJobid        integer   default 0,
-    PurgedFiles       smallint    default 0,
-    HasBase       smallint    default 0,
-    HasCache        smallint    default 0,
-    Reviewed        smallint    default 0,
-    Comment       text,
+    JobTDate	      bigint	  default 0,
+    VolSessionId      integer	  default 0,
+    volSessionTime    integer	  default 0,
+    JobFiles	      integer	  default 0,
+    JobBytes	      bigint	  default 0,
+    ReadBytes	      bigint	  default 0,
+    JobErrors	      integer	  default 0,
+    JobMissingFiles   integer	  default 0,
+    PoolId	      integer	  default 0,
+    FilesetId	      integer	  default 0,
+    PriorJobid	      integer	  default 0,
+    PurgedFiles       smallint	  default 0,
+    HasBase	      smallint	  default 0,
+    HasCache	      smallint	  default 0,
+    Reviewed	      smallint	  default 0,
+    Comment	      text,
     primary key (jobid)
 );
 
 CREATE INDEX job_name_idx on job (name);
 
--- Create a table like Job for long term statistics
+-- Create a table like Job for long term statistics 
 CREATE TABLE JobHisto (LIKE Job);
 CREATE INDEX jobhisto_idx ON JobHisto ( StartTime );
 
 
 CREATE TABLE Location (
-   LocationId       serial    not null,
-   Location       text    not null,
-   Cost         integer   default 0,
-   Enabled        smallint,
+   LocationId	      serial	  not null,
+   Location	      text	  not null,
+   Cost 	      integer	  default 0,
+   Enabled	      smallint,
    primary key (LocationId)
 );
 
 
 CREATE TABLE fileset
 (
-    filesetid       serial    not null,
-    fileset       text    not null,
-    md5         text    not null,
-    createtime        timestamp without time zone not null,
+    filesetid	      serial	  not null,
+    fileset	      text	  not null,
+    md5 	      text	  not null,
+    createtime	      timestamp without time zone not null,
     primary key (filesetid)
 );
 
@@ -154,16 +169,16 @@ CREATE INDEX fileset_name_idx on fileset (fileset);
 
 CREATE TABLE jobmedia
 (
-    jobmediaid        serial    not null,
-    jobid       integer   not null,
-    mediaid       integer   not null,
-    firstindex        integer   default 0,
-    lastindex       integer   default 0,
-    startfile       integer   default 0,
-    endfile       integer   default 0,
-    startblock        bigint    default 0,
-    endblock        bigint    default 0,
-    volindex        integer   default 0,
+    jobmediaid	      serial	  not null,
+    jobid	      integer	  not null,
+    mediaid	      integer	  not null,
+    firstindex	      integer	  default 0,
+    lastindex	      integer	  default 0,
+    startfile	      integer	  default 0,
+    endfile	      integer	  default 0,
+    startblock	      bigint	  default 0,
+    endblock	      bigint	  default 0,
+    volindex	      integer	  default 0,
     primary key (jobmediaid)
 );
 
@@ -171,57 +186,58 @@ CREATE INDEX job_media_job_id_media_id_idx on jobmedia (jobid, mediaid);
 
 CREATE TABLE media
 (
-    mediaid       serial    not null,
-    volumename        text    not null,
-    slot        integer   default 0,
-    poolid        integer   default 0,
-    mediatype       text    not null,
-    mediatypeid       integer   default 0,
-    labeltype       integer   default 0,
+    mediaid	      serial	  not null,
+    volumename	      text	  not null,
+    slot	      integer	  default 0,
+    poolid	      integer	  default 0,
+    mediatype	      text	  not null,
+    mediatypeid       integer	  default 0,
+    labeltype	      integer	  default 0,
     firstwritten      timestamp   without time zone,
     lastwritten       timestamp   without time zone,
-    labeldate       timestamp   without time zone,
-    voljobs       integer   default 0,
-    volfiles        integer   default 0,
-    volblocks       integer   default 0,
-    volmounts       integer   default 0,
-    volbytes        bigint    default 0,
-    volparts        integer   default 0,
-    volerrors       integer   default 0,
-    volwrites       integer   default 0,
-    volcapacitybytes  bigint    default 0,
-    volstatus       text    not null
-  check (volstatus in ('Full','Archive','Append',
-        'Recycle','Purged','Read-Only','Disabled',
-        'Error','Busy','Used','Cleaning','Scratch')),
-    enabled       smallint    default 1,
-    recycle       smallint    default 0,
-    ActionOnPurge     smallint    default 0,
-    volretention      bigint    default 0,
-    voluseduration    bigint    default 0,
-    maxvoljobs        integer   default 0,
-    maxvolfiles       integer   default 0,
-    maxvolbytes       bigint    default 0,
-    inchanger       smallint    default 0,
-    StorageId       integer   default 0,
-    DeviceId        integer   default 0,
-    mediaaddressing   smallint    default 0,
-    volreadtime       bigint    default 0,
-    volwritetime      bigint    default 0,
-    endfile       integer   default 0,
-    endblock        bigint    default 0,
-    LocationId        integer   default 0,
-    recyclecount      integer   default 0,
+    labeldate	      timestamp   without time zone,
+    voljobs	      integer	  default 0,
+    volfiles	      integer	  default 0,
+    volblocks	      integer	  default 0,
+    volmounts	      integer	  default 0,
+    volbytes	      bigint	  default 0,
+    volparts	      integer	  default 0,
+    volerrors	      integer	  default 0,
+    volwrites	      integer	  default 0,
+    volcapacitybytes  bigint	  default 0,
+    volstatus	      text	  not null
+	check (volstatus in ('Full','Archive','Append',
+	      'Recycle','Purged','Read-Only','Disabled',
+	      'Error','Busy','Used','Cleaning','Scratch')),
+    enabled	      smallint	  default 1,
+    recycle	      smallint	  default 0,
+    ActionOnPurge     smallint	  default 0,
+    volretention      bigint	  default 0,
+    voluseduration    bigint	  default 0,
+    maxvoljobs	      integer	  default 0,
+    maxvolfiles       integer	  default 0,
+    maxvolbytes       bigint	  default 0,
+    inchanger	      smallint	  default 0,
+    StorageId	      integer	  default 0,
+    DeviceId	      integer	  default 0,
+    mediaaddressing   smallint	  default 0,
+    volreadtime       bigint	  default 0,
+    volwritetime      bigint	  default 0,
+    endfile	      integer	  default 0,
+    endblock	      bigint	  default 0,
+    LocationId	      integer	  default 0,
+    recyclecount      integer	  default 0,
     initialwrite      timestamp   without time zone,
-    scratchpoolid     integer   default 0,
-    recyclepoolid     integer   default 0,
-    comment       text,
+    scratchpoolid     integer	  default 0,
+    recyclepoolid     integer	  default 0,
+    comment	      text,
     primary key (mediaid)
 );
 
-create unique index media_volumename_id on media (volumename);
+CREATE UNIQUE INDEX media_volumename_id ON Media (VolumeName);
+CREATE INDEX media_poolid_idx ON Media (PoolId);
 
-
+ 
 CREATE TABLE MediaType (
    MediaTypeId SERIAL,
    MediaType TEXT NOT NULL,
@@ -258,32 +274,32 @@ CREATE TABLE Device (
 
 CREATE TABLE pool
 (
-    poolid        serial    not null,
-    name        text    not null,
-    numvols       integer   default 0,
-    maxvols       integer   default 0,
-    useonce       smallint    default 0,
-    usecatalog        smallint    default 0,
-    acceptanyvolume   smallint    default 0,
-    volretention      bigint    default 0,
-    voluseduration    bigint    default 0,
-    maxvoljobs        integer   default 0,
-    maxvolfiles       integer   default 0,
-    maxvolbytes       bigint    default 0,
-    autoprune       smallint    default 0,
-    recycle       smallint    default 0,
-    ActionOnPurge     smallint    default 0,
-    pooltype        text
+    poolid	      serial	  not null,
+    name	      text	  not null,
+    numvols	      integer	  default 0,
+    maxvols	      integer	  default 0,
+    useonce	      smallint	  default 0,
+    usecatalog	      smallint	  default 0,
+    acceptanyvolume   smallint	  default 0,
+    volretention      bigint	  default 0,
+    voluseduration    bigint	  default 0,
+    maxvoljobs	      integer	  default 0,
+    maxvolfiles       integer	  default 0,
+    maxvolbytes       bigint	  default 0,
+    autoprune	      smallint	  default 0,
+    recycle	      smallint	  default 0,
+    ActionOnPurge     smallint	  default 0,
+    pooltype	      text			    
       check (pooltype in ('Backup','Copy','Cloned','Archive','Migration','Scratch')),
-    labeltype       integer   default 0,
-    labelformat       text    not null,
-    enabled       smallint    default 1,
-    scratchpoolid     integer   default 0,
-    recyclepoolid     integer   default 0,
-    NextPoolId        integer   default 0,
-    MigrationHighBytes BIGINT   DEFAULT 0,
-    MigrationLowBytes  BIGINT   DEFAULT 0,
-    MigrationTime      BIGINT   DEFAULT 0,
+    labeltype	      integer	  default 0,
+    labelformat       text	  not null,
+    enabled	      smallint	  default 1,
+    scratchpoolid     integer	  default 0,
+    recyclepoolid     integer	  default 0,
+    NextPoolId	      integer	  default 0,
+    MigrationHighBytes BIGINT	  DEFAULT 0,
+    MigrationLowBytes  BIGINT	  DEFAULT 0,
+    MigrationTime      BIGINT	  DEFAULT 0,
     primary key (poolid)
 );
 
@@ -291,12 +307,12 @@ CREATE INDEX pool_name_idx on pool (name);
 
 CREATE TABLE client
 (
-    clientid        serial    not null,
-    name        text    not null,
-    uname       text    not null,
-    autoprune       smallint    default 0,
-    fileretention     bigint    default 0,
-    jobretention      bigint    default 0,
+    clientid	      serial	  not null,
+    name	      text	  not null,
+    uname	      text	  not null,
+    autoprune	      smallint	  default 0,
+    fileretention     bigint	  default 0,
+    jobretention      bigint	  default 0,
     primary key (clientid)
 );
 
@@ -304,10 +320,10 @@ create unique index client_name_idx on client (name);
 
 CREATE TABLE Log
 (
-    LogId       serial    not null,
-    JobId       integer   not null,
-    Time        timestamp   without time zone,
-    LogText       text    not null,
+    LogId	      serial	  not null,
+    JobId	      integer	  not null,
+    Time	      timestamp   without time zone,
+    LogText	      text	  not null,
     primary key (LogId)
 );
 create index log_name_idx on Log (JobId);
@@ -319,9 +335,9 @@ CREATE TABLE LocationLog (
    MediaId INTEGER DEFAULT 0,
    LocationId INTEGER DEFAULT 0,
    newvolstatus text not null
-  check (newvolstatus in ('Full','Archive','Append',
-        'Recycle','Purged','Read-Only','Disabled',
-        'Error','Busy','Used','Cleaning','Scratch')),
+	check (newvolstatus in ('Full','Archive','Append',
+	      'Recycle','Purged','Read-Only','Disabled',
+	      'Error','Busy','Used','Cleaning','Scratch')),
    newenabled smallint,
    PRIMARY KEY(LocLogId)
 );
@@ -330,11 +346,11 @@ CREATE TABLE LocationLog (
 
 CREATE TABLE counters
 (
-    counter       text    not null,
-    minvalue        integer   default 0,
-    maxvalue        integer   default 0,
-    currentvalue      integer   default 0,
-    wrapcounter       text    not null,
+    counter	      text	  not null,
+    minvalue	      integer	  default 0,
+    maxvalue	      integer	  default 0,
+    currentvalue      integer	  default 0,
+    wrapcounter       text	  not null,
     primary key (counter)
 );
 
@@ -342,11 +358,11 @@ CREATE TABLE counters
 
 CREATE TABLE basefiles
 (
-    baseid        serial        not null,
-    jobid       integer       not null,
-    fileid        bigint        not null,
-    fileindex       integer         ,
-    basejobid       integer         ,
+    baseid	      serial		    not null,
+    jobid	      integer		    not null,
+    fileid	      bigint		    not null,
+    fileindex	      integer			    ,
+    basejobid	      integer			    ,
     primary key (baseid)
 );
 
@@ -354,14 +370,14 @@ CREATE INDEX basefiles_jobid_idx ON BaseFiles ( JobId );
 
 CREATE TABLE unsavedfiles
 (
-    UnsavedId       integer       not null,
-    jobid       integer       not null,
-    pathid        integer       not null,
-    filenameid        integer       not null,
+    UnsavedId	      integer		    not null,
+    jobid	      integer		    not null,
+    pathid	      integer		    not null,
+    filenameid	      integer		    not null,
     primary key (UnsavedId)
 );
 
-CREATE TABLE CDImages
+CREATE TABLE CDImages 
 (
    MediaId integer not null,
    LastBurn timestamp without time zone not null,
@@ -376,8 +392,8 @@ CREATE TABLE PathHierarchy
      CONSTRAINT pathhierarchy_pkey PRIMARY KEY (PathId)
 );
 
-CREATE INDEX pathhierarchy_ppathid
-    ON PathHierarchy (PPathId);
+CREATE INDEX pathhierarchy_ppathid 
+	  ON PathHierarchy (PPathId);
 
 CREATE TABLE PathVisibility
 (
@@ -388,11 +404,11 @@ CREATE TABLE PathVisibility
       CONSTRAINT pathvisibility_pkey PRIMARY KEY (JobId, PathId)
 );
 CREATE INDEX pathvisibility_jobid
-       ON PathVisibility (JobId);
+	     ON PathVisibility (JobId);
 
 CREATE TABLE version
 (
-    versionid       integer       not null
+    versionid	      integer		    not null
 );
 
 CREATE TABLE Status (
@@ -452,7 +468,7 @@ INSERT INTO Version (VersionId) VALUES (14);
 
 END-OF-DATA
 pstat=$?
-if test $pstat = 0;
+if test $pstat = 0; 
 then
    echo "Creation of Bacula PostgreSQL tables succeeded."
 else


### PR DESCRIPTION
This is a sync with upstream 7.0.5, it's mostly whitespace except for CREATE INDEX media_poolid_idx ON Media (PoolId);
