### PR TITLE
add missing parameter to bacula::client

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -15,6 +15,7 @@ class bacula::client (
   $services            = $bacula::params::bacula_client_services,
   $conf_dir            = $bacula::params::conf_dir,
   $director            = $bacula::params::bacula_director,
+  $group               = $bacula::params::bacula_group,
   ) inherits bacula::params {
 
   include bacula::common


### PR DESCRIPTION
otherwise bacula-fd.conf would end up owner by group '_puppet'

This was a regression introduced in 0b722056.
