### PR TITLE
Allow for better control over permissions on $conf_dir and $homedir

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -7,10 +7,11 @@
 # manifest.
 #
 class bacula::common (
-  $homedir  = $bacula::params::homedir,
-  $packages = $bacula::params::bacula_client_packages,
-  $user     = $bacula::params::bacula_user,
-  $group    = $bacula::params::bacula_group,
+  $homedir      = $bacula::params::homedir,
+  $homedir_mode = '0700',
+  $packages     = $bacula::params::bacula_client_packages,
+  $user         = $bacula::params::bacula_user,
+  $group        = $bacula::params::bacula_group,
 ) inherits bacula::params {
 
   include bacula::ssl
@@ -20,7 +21,7 @@ class bacula::common (
     ensure  => directory,
     owner   => $user,
     group   => $group,
-    mode    => '0700',
+    mode    => $homedir_mode,
     require => Package[$packages],
   }
 }

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -2,13 +2,15 @@
 #
 # Manage the SSL deployment for bacula components, Director, Storage, and File.
 class bacula::ssl (
-  $ssl_dir  = $bacula::params::ssl_dir,
-  $conf_dir = $bacula::params::conf_dir,
-  $certfile = $bacula::params::certfile,
-  $keyfile  = $bacula::params::keyfile,
-  $cafile   = $bacula::params::cafile,
-  $packages = $bacula::params::bacula_client_packages,
-  $user     = $bacula::params::bacula_user,
+  $ssl_dir    = $bacula::params::ssl_dir,
+  $conf_dir   = $bacula::params::conf_dir,
+  $certfile   = $bacula::params::certfile,
+  $keyfile    = $bacula::params::keyfile,
+  $cafile     = $bacula::params::cafile,
+  $packages   = $bacula::params::bacula_client_packages,
+  $user       = $bacula::params::bacula_user,
+  $conf_user  = $user,
+  $conf_group = $bacula::params::bacula_group,
 ) inherits bacula::params {
 
   $ssl_files = [
@@ -25,6 +27,8 @@ class bacula::ssl (
   }
 
   file { $conf_dir:
+    owner  => $conf_user,
+    group  => $conf_group,
     ensure => 'directory'
   } ->
 


### PR DESCRIPTION
This enables one to set the same permissions as used in the OpenBSD
package (and thus prevent needless changes after installing/updating).
