### PR TITLE
Reorder ensure in ssl.pp to remove puppet-lint error

### DIFF
--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -27,13 +27,13 @@ class bacula::ssl (
   }
 
   file { $conf_dir:
+    ensure => 'directory',
     owner  => $conf_user,
     group  => $conf_group,
-    ensure => 'directory'
   } ->
 
   file { "${conf_dir}/ssl":
-    ensure => 'directory'
+    ensure => 'directory',
   }
 
   file { $certfile:


### PR DESCRIPTION
In order to make the travis build succeed, this simple re-order in ssl.pp should suffice.
