### PR TITLE
Tweak templates to get rid of stray or errornous whitespace

### DIFF
--- a/templates/bacula-dir-header.erb
+++ b/templates/bacula-dir-header.erb
@@ -7,10 +7,10 @@ Director {                # define myself
     Maximum Concurrent Jobs = <%= @max_concurrent_jobs %>
     Password                = "<%= @password %>"  # Console password
     Messages                = Daemon
-    <% if scope.lookupvar('bacula::params::ssl') -%>
-    <%= scope.function_template(['bacula/_ssl.erb']) %>
+<% if scope.lookupvar('bacula::params::ssl') -%>
+<%= scope.function_template(['bacula/_ssl.erb']) %>
     TLS DH File             = <%= @conf_dir %>/ssl/dh1024.pem
-    <% end -%>
+<% end -%>
 }
 
 Pool {

--- a/templates/bacula-dir-storage.erb
+++ b/templates/bacula-dir-storage.erb
@@ -5,6 +5,6 @@ Storage {
   Password   = "<%= @password %>"
   Device     = <%= @device_name %>
   Media Type = <%= @media_type %>
-  <%= scope.function_template(['bacula/_ssl.erb']) %>
+<%= scope.function_template(['bacula/_ssl.erb']) %>
 }
 

--- a/templates/bacula-fd-header.erb
+++ b/templates/bacula-fd-header.erb
@@ -1,15 +1,14 @@
-
 Director {
   Name     = <%= @director %>-dir
   Password = "<%= @password %>"
-  <%= scope.function_template(['bacula/_ssl.erb']) %>
+<%= scope.function_template(['bacula/_ssl.erb']) %>
 }
 
 Director {
   Name     = <%= @director %>-mon
   Password = "<%= @password %>"
   Monitor  = yes
-  <%= scope.function_template(['bacula/_ssl.erb']) %>
+<%= scope.function_template(['bacula/_ssl.erb']) %>
 }
 
 FileDaemon {
@@ -19,5 +18,5 @@ FileDaemon {
   WorkingDirectory        = <%= @homedir %>
   Pid Directory           = <%= @rundir %>
   Maximum Concurrent Jobs = <%= @max_concurrent_jobs %>
-  <%= scope.function_template(['bacula/_ssl.erb']) %>
+<%= scope.function_template(['bacula/_ssl.erb']) %>
 }

--- a/templates/bacula-sd-dir.erb
+++ b/templates/bacula-sd-dir.erb
@@ -2,6 +2,6 @@
 Director {
   Name     = <%= @director %>-dir
   Password = "<%= @password %>"
-  <%= scope.function_template(['bacula/_ssl.erb']) %>
+<%= scope.function_template(['bacula/_ssl.erb']) %>
 }
 

--- a/templates/bacula-sd-header.erb
+++ b/templates/bacula-sd-header.erb
@@ -3,7 +3,7 @@ Storage {
   WorkingDirectory        = <%= @homedir %>
   Pid Directory           = <%= @rundir %>
   SDPort                  = <%= @port %>
-  <%= scope.function_template(['bacula/_ssl.erb']) %>
+<%= scope.function_template(['bacula/_ssl.erb']) %>
 }
 
 Device {

--- a/templates/bconsole.conf.erb
+++ b/templates/bconsole.conf.erb
@@ -7,6 +7,6 @@ Director {
   DIRport  = <%= @port %>
   address  = <%= scope.lookupvar('bacula::params::director_address') %>
   Password = "<%= @password %>"
-  <%= scope.function_template(['bacula/_ssl.erb']) %>
+<%= scope.function_template(['bacula/_ssl.erb']) %>
 }
 

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -7,6 +7,6 @@ Client {
   File Retention = <%= @file_retention %>
   Job Retention  = <%= @job_retention %>
   AutoPrune      = <%= @autoprune %>
-  <%= scope.function_template(['bacula/_ssl.erb']) %>
+<%= scope.function_template(['bacula/_ssl.erb']) %>
 }
 

--- a/templates/fileset.conf.erb
+++ b/templates/fileset.conf.erb
@@ -3,16 +3,16 @@ FileSet {
   Include {
     Options {
 <% @options.each do |option,value| -%>
-<%=    "      #{option} = #{value}"%>
+<%=    "      #{option} = #{value}" %>
 <% end -%>
     }
-<% [@files].flatten.each do |f| %>
-<%=    "    File = #{f}\n" %>
+<% [@files].flatten.each do |f| -%>
+<%=    "    File = #{f}" %>
 <% end -%>
   }
   Exclude {
-<%   [@excludes].flatten.reject { |x| x.empty? }.flatten.each do |exclude| %>
-<%=    "    File = #{exclude}\n" %>
+<%   [@excludes].flatten.reject { |x| x.empty? }.flatten.each do |exclude| -%>
+<%=    "    File = #{exclude}" %>
 <% end -%>
   }
 }


### PR DESCRIPTION
This removes some newlines in the fileset resource and prevents the "TLS enable" directive from being indented two spaces.
