### PR TITLE
Prevent duplicate resources in the class introduced to prevent just that

### DIFF
--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -7,11 +7,10 @@ class bacula::virtual(
   $director_packages = $bacula::params::bacula_director_packages,
   $storage_packages  = $bacula::params::bacula_storage_packages,
 ) inherits bacula::params {
-  @package { $director_packages:
-    ensure => present
-  }
-
-  @package { $storage_packages:
+  # Get the union of all the packages so we prevent having duplicate packages,
+  # which is exactly the reason for having a virtual package resource.
+  $packages = union($director_packages, $storage_packages)
+  @package { $packages:
     ensure => present
   }
 }


### PR DESCRIPTION
It originally "worked" because of the typo, but the fix in 4f0e9751 actually uncovered the real issue.
