### PR TITLE
label parameter is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,6 @@ Define a Bacula [Pool]() resource. Parameters are:
   Bacula `Action On Purge` directive.
   Defaults to `Truncate`.
 - `label`:
-  Defaults to `''`. Bacula `Label Format` directive.
+  Bacula `Label Format` directive.
 - `storage`: name of the `Storage` resource backing the pool.
   Defaults to `$bacula::params::bacula_storage`. Bacula `Storage` directive.

--- a/manifests/director/pool.pp
+++ b/manifests/director/pool.pp
@@ -31,11 +31,11 @@ define bacula::director::pool (
     $maxvoljobs,
     $maxvolbytes,
     $maxvols,
+    $label,
     $pooltype    = 'Backup',
     $recycle     = 'Yes',
     $autoprune   = 'Yes',
     $purgeaction = 'Truncate',
-    $label       = '',
     $storage     = $bacula::params::bacula_storage
   ) {
 


### PR DESCRIPTION
otherwise bacula fails with:

```
Config error: expected a name, got T_EOL: =
            : line 9, col 26 of file /etc/bacula/conf.d/pools.conf
  Label Format         =
```
