### PR TITLE
testing and Puppet 4 support.

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -11,7 +11,7 @@
 #
 # class { 'bacula::common': }
 class bacula::common(
-    $packages = '',
+    $packages,
     $manage_db_tables,
     $db_backend,
     $db_user,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -135,7 +135,7 @@ class bacula::config {
   }
 
   $director_package = $::bacula_director_package ? {
-    undef   => "void", # By default, let the db package handle this
+    undef   => false, # By default, let the db package handle this
     default => $::bacula_director_package,
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -115,32 +115,32 @@ class bacula::config {
   }
 
   $director_password = $::bacula_director_password ? {
-    undef   => '',
+    undef   => false,
     default => $::bacula_director_password,
   }
 
   $console_password = $::bacula_console_password ? {
-    undef   => '',
+    undef   => false,
     default => $::bacula_console_password,
   }
 
   $director_server = $::bacula_director_server ? {
-    undef   => '',
+    undef   => false,
     default => $::bacula_director_server,
   }
 
   $storage_server = $::bacula_storage_server ? {
-    undef   => '',
+    undef   => false,
     default => $::bacula_storage_server,
   }
 
   $director_package = $::bacula_director_package ? {
-    undef   => '', # By default, let the db package handle this
+    undef   => "void", # By default, let the db package handle this
     default => $::bacula_director_package,
   }
 
   $storage_package = $::bacula_storage_package ? {
-    undef   => '', # By default, let the db package handle this
+    undef   => false, # By default, let the db package handle this
     default => $::bacula_storage_package,
   }
 
@@ -170,7 +170,7 @@ class bacula::config {
   }
 
   $director_db_package = $::bacula_director_db_package ? {
-    undef   => '',
+    undef   => false,
     default => $::bacula_director_db_package,
   }
 
@@ -180,12 +180,12 @@ class bacula::config {
   }
 
   $storage_db_package = $::bacula_storage_db_package ? {
-    undef   => '',
+    undef   => false,
     default => $::bacula_director_db_package,
   }
 
   $db_user = $::bacula_db_user ? {
-    undef   => '',
+    undef   => false,
     default => $::bacula_db_user,
   }
  
@@ -195,7 +195,7 @@ class bacula::config {
   }
 
   $db_password = $::bacula_db_password ? {
-    undef   => '',
+    undef   => false,
     default => $::bacula_db_password,
   }
 

--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -24,7 +24,7 @@ class bacula::console(
     $template = 'bacula/bconsole.conf.erb'
   ) {
 
-  $director_name_array = split($server, '[.]')
+  $director_name_array = split($director_server, '[.]')
   $director_name = $director_name_array[0]
 
   if $console_package {

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -46,7 +46,7 @@ class bacula::director(
     $db_database,
     $db_port,
     $storage_server,
-    $director_package = '',
+    $director_package,
     $mysql_package,
     $mail_to,
     $sqlite_package,
@@ -103,10 +103,6 @@ class bacula::director(
     group   => 'bacula',
     content => template($template),
     notify  => Service['bacula-director'],
-    require => $db_package ? {
-      ''      => undef,
-      default => Package[$db_package],
-    }
   }
 
   file { '/etc/bacula/bacula-dir.d':

--- a/spec/acceptance/bacula_spec.rb
+++ b/spec/acceptance/bacula_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper_acceptance'
+
+describe 'bacula class' do
+  describe 'with sample parameters' do
+    it 'should idempotently run' do
+      pp = <<-EOS
+        class { 'bacula':
+          is_storage        => false,
+          is_director       => false,
+          is_client         => true,
+          manage_console    => true,
+          director_password => 'xxxxxxxxx',
+          console_password  => 'xxxxxxxxx',
+          director_server   => 'bacula.domain.com',
+          mail_to           => 'bacula-admin@domain.com',
+          storage_server    => 'bacula.domain.com',
+          clients           => $clients,
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+  end
+end

--- a/spec/acceptance/nodesets/centos-6-x64.yml
+++ b/spec/acceptance/nodesets/centos-6-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  centos-6-x64:
+    roles:
+      - default
+    platform: el-6-x86_64
+    box: puppetlabs/centos-6.6-64-puppet
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  centos-7-x64:
+    roles:
+      - default
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: aio

--- a/spec/acceptance/nodesets/debian-7-x64.yml
+++ b/spec/acceptance/nodesets/debian-7-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  debian-7-x64:
+    roles:
+      - default
+    platform: debian-7-x86_64
+    box: puppetlabs/debian-7.8-64-puppet
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  ubuntu-1404-x64:
+    roles:
+      - default
+    platform: ubuntu-1404-x86_64
+    box: puppetlabs/ubuntu-14.04-64-puppet
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/classes/bacula_spec.rb
+++ b/spec/classes/bacula_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'bacula' do
 
-  context 'with standard parameters' do
+  context 'with default parameters' do
     let(:params) {
       {
         :is_storage        => true,
@@ -16,12 +16,45 @@ describe 'bacula' do
         :storage_server    => 'bacula.domain.com',
       }
     }
+    it { should contain_class('bacula') }
     it { should contain_class('bacula::common') }
+    it { should contain_class('bacula::config') }
     it { should contain_class('bacula::config::validate') }
     it { should contain_class('bacula::director') }
     it { should contain_class('bacula::storage') }
     it { should contain_class('bacula::client') }
     it { should contain_class('bacula::console') }
+
+    it { should contain_exec('make_db_tables') }
+
+    it { should contain_file ('/etc/bacula/') }
+    it { should contain_file ('/etc/bacula/bacula-dir.conf') }
+    it { should contain_file ('/etc/bacula/bacula-dir.d/empty.conf') }
+    it { should contain_file ('/etc/bacula/bacula-dir.d') }
+    it { should contain_file ('/etc/bacula/bacula-fd.conf') }
+    it { should contain_file ('/etc/bacula/bacula-sd.conf') }
+    it { should contain_file ('/etc/bacula/bacula-sd.d/empty.conf') }
+    it { should contain_file ('/etc/bacula/bacula-sd.d') }
+    it { should contain_file ('/etc/bacula/bconsole.conf') }
+    it { should contain_file ('/mnt/bacula') }
+    it { should contain_file ('/mnt/bacula/default') }
+    it { should contain_file ('/var/lib/bacula') }
+    it { should contain_file ('/var/log/bacula') }
+    it { should contain_file ('/var/run/bacula') }
+    it { should contain_file ('/var/spool/bacula') }
+
+    it { should contain_group ('bacula') }
+
+    it { should contain_package ('bacula-client') }
+    it { should contain_package ('bacula-console') }
+    it { should contain_package ('bacula-director-sqlite3') }
+    it { should contain_package ('bacula-sd-sqlite3') }
+
+    it { should contain_service ('bacula-director') }
+    it { should contain_service ('bacula-fd') }
+    it { should contain_service ('bacula-sd') }
+
+    it { should contain_user ('bacula') }
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,30 @@
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+
+hosts.each do |host|
+  # Install Puppet 4 on CentOS 7
+  if host['platform'] =~ /el-7/
+    on host, 'yum install -y http://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
+    on host, 'yum install -y install puppet-agent'
+  else
+  # Install Puppet 3.x on any other OS
+    install_puppet
+  end
+end
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(:source => proj_root, :module_name => 'bacula')
+    hosts.each do |host|
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+    end
+  end
+end

--- a/templates/bacula-dir.conf.erb
+++ b/templates/bacula-dir.conf.erb
@@ -18,10 +18,10 @@ Director {
 # This is where the catalog information will be stored (basically
 # this should be how to connect to whatever database we're using)
 Catalog {
-  Name = "<%= @director_name -%>:<%= db_backend -%>"
-  dbname = "<%= db_database -%>"; dbdriver = dbi:<%= db_backend %>
-  <% unless db_backend == 'sqlite' -%>
-  dbaddress = <%= db_host %>; dbport = <%= db_port %>; user = <%= db_user %>; password = <%= db_password %>
+  Name = "<%= @director_name -%>:<%= @db_backend -%>"
+  dbname = "<%= @db_database -%>"; dbdriver = dbi:<%= @db_backend %>
+  <% unless @db_backend == 'sqlite' -%>
+  dbaddress = <%= @db_host %>; dbport = <%= @db_port %>; user = <%= @db_user %>; password = <%= @db_password %>
   <% end %>
 }
 
@@ -29,10 +29,10 @@ Catalog {
 # should should be for just about everything.
 Messages {
   Name = "<%= @director_name -%>:messages:standard"
-  Mail Command = "/usr/lib/bacula/bsmtp -h localhost -f bacula@<%= domain -%> -s \"Bacula %t %e (for %c)\" %r"
-  Operator Command = "/usr/lib/bacula/bsmtp -h localhost -f bacula@<%= domain -%> -s \"Bacula Intervention Required (for %c)\" %r"
-  Mail = <%= mail_to -%> = all, !skipped
-  Operator = <%= mail_to -%> = mount
+  Mail Command = "/usr/lib/bacula/bsmtp -h localhost -f bacula@<%= @domain -%> -s \"Bacula %t %e (for %c)\" %r"
+  Operator Command = "/usr/lib/bacula/bsmtp -h localhost -f bacula@<%= @domain -%> -s \"Bacula Intervention Required (for %c)\" %r"
+  Mail = <%= @mail_to -%> = all, !skipped
+  Operator = <%= @mail_to -%> = mount
   Console = all, !skipped, !saved
   # WARNING! the following will create a file that you must cycle from
   #          time to time as it will grow indefinitely. However, it will
@@ -44,17 +44,17 @@ Messages {
 # These are messages directly from the various daemons themselves.
 Messages {
   Name = "<%= @director_name -%>:messages:daemon"
-  Mail Command = "/usr/lib/bacula/bsmtp -h localhost -f bacula@<%= domain -%> -s \"Bacula Notice (from Director %d)\" %r"
-  Mail = <%= mail_to -%> = all, !skipped
+  Mail Command = "/usr/lib/bacula/bsmtp -h localhost -f bacula@<%= @domain -%> -s \"Bacula Notice (from Director %d)\" %r"
+  Mail = <%= @mail_to -%> = all, !skipped
   Console = all, !skipped, !saved
   Append = "/var/log/bacula/<%= @director_name -%>:director.log" = all, !skipped
 }
 
-<% if use_console -%>
+<% if @use_console -%>
 # Restricted console used by tray-monitor to get the status of the director
 Console {
   Name = "<%= @director_name -%>:monitor:director"
-  Password = "<%= console_password -%>"
+  Password = "<%= @console_password -%>"
   CommandACL = status, .status
 }
 <% end -%>
@@ -66,15 +66,15 @@ Console {
 # Storage Daemon to connect to (using the standard FileStorage device) and a
 # Pool which will be used with that as well.
 Storage {
-  Name = "<%= storage_name -%>:storage:default"
-  Address = <%= storage_name %>
+  Name = "<%= @storage_name -%>:storage:default"
+  Address = <%= @storage_name %>
   Password = "<%= @password -%>"
   Device = "FileStorage"
   Media Type = File
 }
 
 Pool {
-  Name = "<%= storage_name -%>:pool:default"
+  Name = "<%= @storage_name -%>:pool:default"
   # All Volumes will have the format standard.date.time to ensure they
   # are kept unique throughout the operation and also aid quick analysis
   # We won't use a counter format for this at the moment.
@@ -90,10 +90,10 @@ Pool {
 }
 
 Pool {
-  Name = "<%= storage_name -%>:pool:catalog"
+  Name = "<%= @storage_name -%>:pool:catalog"
   # All Volumes will have the format director.catalog.date.time to ensure they
   # are kept unique throughout the operation and also aid quick analysis
-  Label Format = "<%= @director_name -%>.catalog.${Counter<%= server.capitalize -%>Catalog+:p/3/0/r}"
+  Label Format = "<%= @director_name -%>.catalog.${Counter<%= @server.capitalize -%>Catalog+:p/3/0/r}"
   Pool Type = Backup
   # Clean up any we don't need, and keep them for a maximum of a month (in
   # theory the same time period for weekly backups from the clients)
@@ -108,9 +108,9 @@ Pool {
 
 # Create a Counter which will be used to label the catalog volumes on the sytem
 Counter {
-  Name    = "Counter<%= server.capitalize -%>Catalog"
+  Name    = "Counter<%= @server.capitalize -%>Catalog"
   Minimum = 1
-  Catalog = "<%= @director_name -%>:<%= db_backend %>"
+  Catalog = "<%= @director_name -%>:<%= @db_backend %>"
 }
 
 # FILE SETS -------------------------------------------------------------------
@@ -298,8 +298,8 @@ JobDefs {
   Messages = "<%= @director_name -%>:messages:standard"
   # Set the job to work as standard with the default Pool & Storage
   # (this will be overridden by the Job configuration for each Client)
-  Storage = "<%= storage_name -%>:storage:default"
-  Pool = "<%= storage_name -%>:pool:default"
+  Storage = "<%= @storage_name -%>:storage:default"
+  Pool = "<%= @storage_name -%>:pool:default"
   Write Bootstrap = "/var/lib/bacula/%c.bsr"
   Priority = 15
   # Define how long any of these jobs are allowed to run for before we should

--- a/templates/bacula-fd.conf.erb
+++ b/templates/bacula-fd.conf.erb
@@ -1,25 +1,25 @@
 # DO NOT EDIT - Managed by Puppet
 #
 # Bacula File Daemon Configuration
-#   for <%= hostname.split('.').first %>
-#   via <%= director_server -%>:director (<%= director_server -%>)
+#   for <%= @hostname.split('.').first %>
+#   via <%= @director_server -%>:director (<%= @director_server -%>)
 
 # Configure the Director which will manage this host's backups
 Director {
-  Name = "<%= director_name -%>:director"
-  Password = "<%= director_password -%>"
+  Name = "<%= @director_name -%>:director"
+  Password = "<%= @director_password -%>"
 }
 
 # Now configure the actual File Daemon
 FileDaemon {
-  Name = "<%= hostname.split('.').first -%>"
-  Working Directory = <%= working_dir %>
-  PID Directory = <%= pid_dir %>
+  Name = "<%= @hostname.split('.').first -%>"
+  Working Directory = <%= @working_dir %>
+  PID Directory = <%= @pid_dir %>
   Maximum Concurrent Jobs = 3
 }
 
 # Finally, set where the messages are going to go
 Messages {
-  Name = "<%= director_name -%>:messages:standard"
-  Director = "<%= director_name -%>:director" = all, !skipped, !restored
+  Name = "<%= @director_name -%>:messages:standard"
+  Director = "<%= @director_name -%>:director" = all, !skipped, !restored
 }

--- a/templates/bacula-sd.conf.erb
+++ b/templates/bacula-sd.conf.erb
@@ -1,24 +1,24 @@
 # DO NOT EDIT - Managed by Puppet
 #
 # Bacula Storage Daemon Configuration
-#   for <%= storage_name %>
-#   via <%= director_name -%>:director (<%= director_name -%>)
+#   for <%= @storage_name %>
+#   via <%= @director_name -%>:director (<%= @director_name -%>)
 
 # Configure the Director which will manage this Storage Daemon, and the
 # Director through which we'll send our messages (will be the same) one.
 Director {
-  Name = "<%= director_name -%>:director"
-  Password = "<%= director_password -%>"
+  Name = "<%= @director_name -%>:director"
+  Password = "<%= @director_password -%>"
 }
 
 Messages {
-  Name = "<%= storage_name -%>:messages:standard"
-  Director = "<%= director_name -%>:director" = all
+  Name = "<%= @storage_name -%>:messages:standard"
+  Director = "<%= @director_name -%>:director" = all
 }
 
 # Configure the basic details for the Storage Daemon on this server
 Storage {
-  Name = "<%= storage_name -%>:storage"
+  Name = "<%= @storage_name -%>:storage"
   Working Directory = "/var/lib/bacula"
   PID Directory = "/var/run/bacula"
   Maximum Concurrent Jobs = 20
@@ -26,8 +26,8 @@ Storage {
 
 # Also configure access for something to monitor this Storage Daemon
 Director {
-  Name = "<%= storage_name -%>:monitor:storage"
-  Password = "<%= console_password -%>"
+  Name = "<%= @storage_name -%>:monitor:storage"
+  Password = "<%= @console_password -%>"
   Monitor = Yes
 }
 

--- a/templates/bconsole.conf.erb
+++ b/templates/bconsole.conf.erb
@@ -1,11 +1,11 @@
 # DO NOT EDIT - Managed by Puppet
 #
 # Bacula Console Configuration
-#   for <%= fqdn %>
-#    to <%= director_name -%>:director (<%= director_server -%>)
+#   for <%= @fqdn %>
+#    to <%= @director_name -%>:director (<%= @director_server -%>)
 
 Director {
-  Name = "<%= director_name -%>:monitor:director"
-  Address = <%= director_server %>
-  Password = "<%= director_password -%>"
+  Name = "<%= @director_name -%>:monitor:director"
+  Address = <%= @director_server %>
+  Password = "<%= @director_password -%>"
 }


### PR DESCRIPTION
testing
  - adds beaker config including specs and nodesets
  - adds beaker nodes for debian, centos 6 & 7
  - adds coverage report for rspec tests
adds compatibility with puppuet 4
  - reworks variable lookup in templates