### PR TITLE
Set min version_requirement for Puppet + deps

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppet-bacula",
   "version": "0.0.3-rc0",
   "source": "https://github.com/voxpupuli/puppet-bacula",
-  "author": "voxpupuli",
+  "author": "Vox Pupuli",
   "license": "Apache-2.0",
   "summary": "Installs and configures Bacula",
   "description": "Installs and configures Bacula",
@@ -10,15 +10,21 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_range": ">= 2.2.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/mysql",
-      "version_range": ">= 0.0.1"
+      "version_requirement": ">= 3.5.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/sqlite",
-      "version_range": ">= 0.0.1"
+      "version_requirement": ">= 0.0.1 < 2.0.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata

Also fix author