### PR TITLE
Add $ensure parameter for Bacula packages

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,10 +10,8 @@ bacula::director::messages:
       append:       '"/var/log/bacula/bacula-dir.log" = all, !skipped'
       catalog:      'all'
 bacula::director::packages: []
-bacula::director::ensure: 'present'
 
 bacula::storage::services: 'bacula-sd'
-bacula::storage::ensure: 'present'
 bacula::storage_name: '%{trusted.certname}'
 
 bacula::director_name: '%{trusted.certname}'
@@ -22,7 +20,6 @@ bacula::job_tag: ~
 
 bacula::client::services: 'bacula-fd'
 bacula::client::packages: ~
-bacula::client::ensure: 'present'
 bacula::client::default_pool: 'Default'
 bacula::client::default_pool_full: ~
 bacula::client::default_pool_inc: ~

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,8 +10,10 @@ bacula::director::messages:
       append:       '"/var/log/bacula/bacula-dir.log" = all, !skipped'
       catalog:      'all'
 bacula::director::packages: []
+bacula::director::ensure: 'present'
 
 bacula::storage::services: 'bacula-sd'
+bacula::storage::ensure: 'present'
 bacula::storage_name: '%{trusted.certname}'
 
 bacula::director_name: '%{trusted.certname}'
@@ -20,6 +22,7 @@ bacula::job_tag: ~
 
 bacula::client::services: 'bacula-fd'
 bacula::client::packages: ~
+bacula::client::ensure: 'present'
 bacula::client::default_pool: 'Default'
 bacula::client::default_pool_full: ~
 bacula::client::default_pool_inc: ~

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -53,7 +53,7 @@
 #
 class bacula::client (
   Array[String]           $packages,
-  String                  $ensure,
+  String                  $ensure              = 'present',
   String                  $services,
   String                  $default_pool,
   Optional[String]        $default_pool_full,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -53,12 +53,12 @@
 #
 class bacula::client (
   Array[String]           $packages,
-  String                  $ensure              = 'present',
   String                  $services,
   String                  $default_pool,
   Optional[String]        $default_pool_full,
   Optional[String]        $default_pool_inc,
   Optional[String]        $default_pool_diff,
+  String                  $ensure              = 'present',
   Integer                 $port                = 9102,
   Array[String[1]]        $listen_address      = [],
   String                  $password            = 'secret',

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -3,6 +3,7 @@
 # This class installs and configures the File Daemon to backup a client system.
 #
 # @param packages            A list of packages to install; loaded from hiera
+# @param ensure              What state the package should be in.
 # @param services            A list of services to operate; loaded from hiera
 # @param default_pool        The name of the Pool for this FD to use by default
 # @param default_pool_full   The name of the Pool to use for Full jobs
@@ -52,6 +53,7 @@
 #
 class bacula::client (
   Array[String]           $packages,
+  String                  $ensure,
   String                  $services,
   String                  $default_pool,
   Optional[String]        $default_pool_full,
@@ -78,7 +80,7 @@ class bacula::client (
   $config_file = "${conf_dir}/bacula-fd.conf"
 
   package { $packages:
-    ensure => present,
+    ensure => $ensure,
   }
 
   service { $services:

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -4,6 +4,7 @@
 #
 # @param messages            Logging configuration; loaded from hiera
 # @param packages            A list of packages to install; loaded from hiera
+# @param ensure              What state the package should be in.
 # @param services            A list of services to operate; loaded from hiera
 # @param manage_db           Whether the module should manage the director database
 # @param conf_dir            Path to bacula configuration directory
@@ -37,6 +38,7 @@
 class bacula::director (
   Hash[String, Bacula::Message] $messages,
   Array[String]                 $packages,
+  String                        $ensure,
   String                        $services,
   String                        $make_bacula_tables,
   Bacula::Yesno                 $manage_db           = true,
@@ -85,7 +87,7 @@ class bacula::director (
       }
     )
   }
-  ensure_packages($package_names)
+  ensure_packages($package_names,{ensure => $ensure})
 
   service { $services:
     ensure  => running,

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -38,7 +38,7 @@
 class bacula::director (
   Hash[String, Bacula::Message] $messages,
   Array[String]                 $packages,
-  String                        $ensure,
+  String                        $ensure              = 'present',
   String                        $services,
   String                        $make_bacula_tables,
   Bacula::Yesno                 $manage_db           = true,

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -38,9 +38,9 @@
 class bacula::director (
   Hash[String, Bacula::Message] $messages,
   Array[String]                 $packages,
-  String                        $ensure              = 'present',
   String                        $services,
   String                        $make_bacula_tables,
+  String                        $ensure              = 'present',
   Bacula::Yesno                 $manage_db           = true,
   String                        $conf_dir            = $bacula::conf_dir,
   String                        $db_name             = 'bacula',
@@ -87,7 +87,7 @@ class bacula::director (
       }
     )
   }
-  ensure_packages($package_names,{ensure => $ensure})
+  ensure_packages($package_names, { ensure => $ensure })
 
   service { $services:
     ensure  => running,

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -56,7 +56,7 @@ class bacula::storage (
       }
     )
   }
-  ensure_packages($package_names,{ensure => $ensure})
+  ensure_packages($package_names, { ensure => $ensure })
 
   service { $services:
     ensure  => running,

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -28,7 +28,7 @@
 class bacula::storage (
   String              $services,
   Array[String]       $packages,
-  String              $ensure,
+  String              $ensure         = 'present',
   String              $conf_dir       = $bacula::conf_dir,
   String              $device         = '/bacula',
   Stdlib::Filemode    $device_mode    = '0770',

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -4,6 +4,7 @@
 #
 # @param services       A list of services to operate; loaded from hiera
 # @param packages       A list of packages to install; loaded from hiera
+# @param ensure         What state the package should be in.
 # @param conf_dir       Path to bacula configuration directory
 # @param device         The system file name of the storage device managed by this storage daemon
 # @param device_mode    The posix mode for device
@@ -27,6 +28,7 @@
 class bacula::storage (
   String              $services,
   Array[String]       $packages,
+  String              $ensure,
   String              $conf_dir       = $bacula::conf_dir,
   String              $device         = '/bacula',
   Stdlib::Filemode    $device_mode    = '0770',
@@ -54,7 +56,7 @@ class bacula::storage (
       }
     )
   }
-  ensure_packages($package_names)
+  ensure_packages($package_names,{ensure => $ensure})
 
   service { $services:
     ensure  => running,


### PR DESCRIPTION
### Preface

While testing this module with **Bacula 11** packages from bacula.org I've run into an issue.

### Bugfixes

These packages have a major difference: the director/storage package is renamed to `bacula-postgresql` and **it already includes the Bacula client**, console, etc. So I had to adjust the configuration like this to get both the director/storage and the client *running on the same host*:

```
# director/storage/client all on the same host
bacula::storage::packages: [ 'bacula-postgresql' ]
bacula::director::packages: [ 'bacula-postgresql' ]
bacula::client::packages: [ 'bacula-postgresql' ]
```

Initially this failed, because it lead to a duplicate declaration error due to the way the `bacula::client` class handled the package installation. After fixing this another issue occured, because the value for `$bacula::client::packages` was not _replaced_ but instead it was merged, resulting in a value of `[ 'bacula-client', 'bacula-postgresql' ]`, which of course did not work.

This PR fixes these issues and I did not notice any side-effects when using it on Bacula 9.

Disclaimer: I've tested this only with Bacula 11 packages from bacula.org, so I don't know whether or not Linux/BSD distributions have adopted this new package naming scheme.

### New Parameter

Furthermore I've noticed that this module does not support updating Bacula. I've added a new `$ensure` parameter to all packages which defaults to `present`. It makes it possible to upgrade to a new Bacula release.

The following example demonstrates the upgrade from Bacula 9 to Bacula 11 on CentOS:

```
# package no longer available in Bacula 11, would prevent upgrade of bacula-client
package { 'bacula-common':
  ensure => absent,
  provider => 'rpm',
  uninstall_options => ['--nodeps'],
}

# upgrade client after removing the old dependency
class { 'bacula::client':
  packages => [ 'bacula-client' ],
  ensure => '11.0.5-1',
}
```