### PR TITLE
Allow to listen on multiple IP addresses

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,7 +9,30 @@
 # @param default_pool_inc    The name of the Pool to use for Incremental jobs
 # @param default_pool_diff   The name of the Pool to use for Differential jobs
 # @param port                The listening port for the File Daemon
-# @param listen_address      The listening INET or INET6 address for File Daemon
+# @param listen_address      The listening IP addresses for the File Daemon
+#   By default, Bacula listen an all IPv4 only, which is equivalent to
+#   ```
+#      listen_address => [
+#        '0.0.0.0',
+#      ],
+#   ```
+#   Listening on both IPv6 and IPv4 depends on your system configuration of
+#   IPv4-mapped IPv6 (RFC 3493): when enabled, the following is enough to
+#   listen on both all IPv6 and all IPv4:
+#   ```
+#      listen_address => [
+#        '::',
+#      ],
+#   ```
+#   If IPv4-mapped IPv6 is not used, each address must be indicated separately:
+#   ```
+#      listen_address => [
+#        '::',
+#        '0.0.0.0',
+#      ],
+#   ```
+#   Indicating both addresses with IPv4-mapped IPv6 enabled will result in
+#   Bacula being unable to bind twice to the IPv4 address and fail to start.
 # @param password            A password to use for communication with this File Daemon
 # @param max_concurrent_jobs Bacula FD option for 'Maximum Concurrent Jobs'
 # @param director_name       The hostname of the director for this FD
@@ -35,7 +58,7 @@ class bacula::client (
   Optional[String]        $default_pool_inc,
   Optional[String]        $default_pool_diff,
   Integer                 $port                = 9102,
-  Optional[String]        $listen_address      = $facts['networking']['ip'],
+  Array[String[1]]        $listen_address      = [],
   String                  $password            = 'secret',
   Integer                 $max_concurrent_jobs = 2,
   String                  $director_name       = $bacula::director_name,

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -17,7 +17,8 @@
 # @param group               The posix group for bacula
 # @param homedir             The bacula director working directory
 # @param job_tag             A string to use when realizing jobs and filesets
-# @param listen_address      The listening address for the director
+# @param listen_address      The listening IP addresses for the director
+#   The notes for `bacula::client::listen_address` apply.
 # @param max_concurrent_jobs Bacula Director option for 'Maximum Concurrent Jobs'
 # @param manage_defaults     Setup default jobdef, schedule, pool and restoration jobs
 # @param password            password to connect to the director
@@ -50,7 +51,7 @@ class bacula::director (
   String                        $group               = $bacula::bacula_group,
   String                        $homedir             = $bacula::homedir,
   Optional[String]              $job_tag             = $bacula::job_tag,
-  Optional[String]              $listen_address      = $facts['networking']['ip'],
+  Array[String[1]]              $listen_address      = [],
   Integer                       $max_concurrent_jobs = 20,
   Boolean                       $manage_defaults     = true,
   String                        $password            = 'secret',

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -13,7 +13,8 @@
 # @param director_name  Specifies the Name of the Director allowed to connect to the Storage daemon
 # @param group          The posix group for bacula
 # @param homedir        The directory in which the Storage daemon may put its status files
-# @param listen_address INET or INET6 address to listen on
+# @param listen_address The listening IP addresses for the storage daemon
+#   The notes for `bacula::client::listen_address` apply.
 # @param maxconcurjobs  maximum number of Jobs that may run concurrently
 # @param media_type     The type of media supported by this device
 # @param password       Specifies the password that must be supplied by the named Director
@@ -35,7 +36,7 @@ class bacula::storage (
   String              $director_name  = $bacula::director_name,
   String              $group          = $bacula::bacula_group,
   String              $homedir        = $bacula::homedir,
-  Optional[String]    $listen_address = $facts['networking']['ip'],
+  Array[String[1]]    $listen_address = [],
   Integer             $maxconcurjobs  = 5,
   String              $media_type     = 'File',
   String              $password       = 'secret',

--- a/templates/_listen.epp
+++ b/templates/_listen.epp
@@ -1,9 +1,10 @@
 <%
   |
-    String              $listen_address,
+    Array[String[1]]    $listen_addresses,
     Optional[Integer]   $port,
   |
 -%>
+<%- $listen_addresses.each |$listen_address| { -%>
         <%= $listen_address ? {
 	      Stdlib::IP::Address::V4::Nosubnet => 'ipv4',
 	      Stdlib::IP::Address::V6::Nosubnet => 'ipv6',
@@ -14,3 +15,4 @@
             port = <%= $port %>;
 <% } -%>
         }
+<%- } -%>

--- a/templates/bacula-dir-header.epp
+++ b/templates/bacula-dir-header.epp
@@ -1,8 +1,8 @@
 Director {                # define myself
     Name                    = <%= $clientcert %>-dir
-<% if $bacula::director::listen_address { -%>
+<% unless $bacula::director::listen_address.empty { -%>
     DirAddresses            = {
-<%= epp('bacula/_listen.epp', { listen_address => $bacula::director::listen_address, port => $bacula::director::port }) %>
+<%= epp('bacula/_listen.epp', { listen_addresses => $bacula::director::listen_address, port => $bacula::director::port }) %>
     }
 <% } -%>
     QueryFile               = "/etc/bacula/scripts/query.sql"

--- a/templates/bacula-fd-header.epp
+++ b/templates/bacula-fd-header.epp
@@ -13,9 +13,9 @@ Director {
 
 FileDaemon {
     Name                    = <%= $bacula::client::client %>-fd
-<% if $bacula::client::listen_address { -%>
+<% unless $bacula::client::listen_address.empty { -%>
     FDAddresses             = {
-<%= epp('bacula/_listen.epp', { listen_address => $bacula::client::listen_address, port => $bacula::client::port }) -%>
+<%= epp('bacula/_listen.epp', { listen_addresses => $bacula::client::listen_address, port => $bacula::client::port }) -%>
     }
 <% } -%>
     WorkingDirectory        = <%= $bacula::client::homedir %>

--- a/templates/bacula-sd-header.epp
+++ b/templates/bacula-sd-header.epp
@@ -2,9 +2,9 @@ Storage {
     Name                    = <%= $clientcert %>-sd
     WorkingDirectory        = <%= $bacula::storage::homedir %>
     Pid Directory           = <%= $bacula::storage::rundir %>
-<% if $bacula::storage::listen_address { -%>
+<% unless $bacula::storage::listen_address.empty { -%>
     SDAddresses             = {
-<%= epp('bacula/_listen.epp', { listen_address => $bacula::storage::listen_address, port => $bacula::storage::port }) -%>
+<%= epp('bacula/_listen.epp', { listen_addresses => $bacula::storage::listen_address, port => $bacula::storage::port }) -%>
     }
 <% } -%>
 <%= epp('bacula/_tls_server.epp') -%>


### PR DESCRIPTION
Allow to pass multiple IP addresses.  The default behavior is to listen on IPv4 only so this is only a breaking change because the interface change.