### PR TITLE
Fix legacy fact usage

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -10,7 +10,7 @@ hierarchy:
     path: 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}.yaml'
 
   - name: 'family'
-    path: 'os/%{facts.osfamily}.yaml'
+    path: 'os/%{facts.os.family}.yaml'
 
   - name: 'common'
     path: 'common.yaml'

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -9,11 +9,11 @@ describe 'bacula::director' do
 
       expected_packages = []
 
-      case facts[:osfamily]
+      case facts[:os]['family']
       when 'Debian'
         it { is_expected.to contain_class('bacula::director') }
 
-        case facts[:operatingsystemmajrelease]
+        case facts[:os]['release']['major']
         when '7', '8'
           expected_packages << 'bacula-director-common'
         when '9'
@@ -22,7 +22,7 @@ describe 'bacula::director' do
         expected_packages << 'bacula-director-pgsql'
         expected_packages << 'bacula-console'
       when 'RedHat'
-        case facts[:operatingsystemmajrelease]
+        case facts[:os]['release']['major']
         when '6'
           expected_packages << 'bacula-director-common'
           expected_packages << 'bacula-console'

--- a/spec/classes/storage_spec.rb
+++ b/spec/classes/storage_spec.rb
@@ -18,16 +18,16 @@ describe 'bacula::storage' do
 
       it { is_expected.to contain_class('bacula::storage') }
 
-      case facts[:osfamily]
+      case facts[:os]['family']
       when 'Debian'
         it { is_expected.to contain_package('bacula-sd') }
 
-        case facts[:operatingsystemmajrelease]
+        case facts[:os]['release']['major']
         when '7', '8'
           it { is_expected.to contain_package('bacula-sd-pgsql') }
         end
       when 'RedHat'
-        case facts[:operatingsystemmajrelease]
+        case facts[:os]['release']['major']
         when '6'
           it do
             is_expected.to contain_package('bacula-storage-common').with(


### PR DESCRIPTION
Prefer `os.family` to `osfamily`.  This allows to test control-repos
catalogs with onceover using factsets that do not include legacy facts.
