### PR TITLE
Relax dependencies version requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 4.1.0 < 9.0.0"
+      "version_requirement": ">= 4.1.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.0.0 < 8.0.0"
+      "version_requirement": ">= 1.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.1 < 9.0.0"
+      "version_requirement": ">= 4.25.1 < 10.0.0"
     },
     {
       "name": "puppetlabs/postgresql",


### PR DESCRIPTION
- Allow puppetlabs-stdlib 9.x
- Allow puppetlabs-concat 9.x
- Allow pupplabs-postgresql 9.x
