### PR TITLE
Remove legacy backwards-compatible data types

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -971,7 +971,7 @@ The address of the Bacula File server daemon
 
 ##### <a name="-bacula--director--client--port"></a>`port`
 
-Data type: `Variant[String,Integer]`
+Data type: `Stdlib::Port`
 
 The port of the Bacula File server daemon
 
@@ -1168,7 +1168,7 @@ Default value: `undef`
 
 ##### <a name="-bacula--director--pool--maxvoljobs"></a>`maxvoljobs`
 
-Data type: `Optional[Variant[String,Integer]]`
+Data type: `Optional[Integer[1]]`
 
 Bacula pool configuration option "Maximum Volume Jobs"
 
@@ -1184,7 +1184,7 @@ Default value: `undef`
 
 ##### <a name="-bacula--director--pool--maxvols"></a>`maxvols`
 
-Data type: `Optional[Variant[String,Integer]]`
+Data type: `Optional[Integer[1]]`
 
 Bacula pool configuration option "Maximum Volumes"
 

--- a/manifests/director/client.pp
+++ b/manifests/director/client.pp
@@ -24,7 +24,7 @@
 #
 define bacula::director::client (
   String                  $address,
-  Variant[String,Integer] $port, # FIXME: Remove String
+  Stdlib::Port            $port,
   String                  $password,
   Bacula::Time            $file_retention,
   Bacula::Time            $job_retention,

--- a/manifests/director/pool.pp
+++ b/manifests/director/pool.pp
@@ -30,9 +30,9 @@
 #
 define bacula::director::pool (
   Optional[String]                  $volret         = undef,
-  Optional[Variant[String,Integer]] $maxvoljobs     = undef, # FIXME: Remove String
+  Optional[Integer[1]]              $maxvoljobs     = undef,
   Optional[Bacula::Size]            $maxvolbytes    = undef,
-  Optional[Variant[String,Integer]] $maxvols        = undef, # FIXME: Remove String
+  Optional[Integer[1]]              $maxvols        = undef,
   Optional[String]                  $label          = undef,
   Optional[String]                  $voluseduration = undef,
   String                            $storage        = $bacula::director::storage,


### PR DESCRIPTION
When data types where added in version 5.4.0 a few years ago (#117),
backward compatibility with old catalog that used String for all
parameters was preserved.

We already did a few major releases so keeping this backward
compatibility does not make sense and we can make the types more
consistent by removing them.
