### PR TITLE
Manage storage directories after intallation

### DIFF
--- a/manifests/storage/device.pp
+++ b/manifests/storage/device.pp
@@ -36,6 +36,8 @@ define bacula::storage::device (
   String           $director_name   = $bacula::director_name,
   String           $group           = $bacula::bacula_group,
 ) {
+  include bacula::storage
+
   $epp_device_variables = {
     device_name     => $device_name,
     media_type      => $media_type,
@@ -60,6 +62,7 @@ define bacula::storage::device (
       group   => $group,
       mode    => $device_mode,
       seltype => $device_seltype,
+      require => Package[$bacula::storage::package_names],
     }
   }
 }


### PR DESCRIPTION
When creating a storage directory, we want to set correct ownership for
it but before the bacula-sd package is installed, the bacula user and
group may not be available, resulting in a catalog appliaction failure.

Explicitly require the storage daemon package to make sure the
user/group are available when the directory is created.
