### PR TITLE
Adopt new service names on FreeBSD

### DIFF
--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -2,11 +2,11 @@
 bacula::director::make_bacula_tables: '/usr/local/share/bacula/make_postgresql_tables'
 
 bacula::director::packages: [ 'bacula9-server' ]
-bacula::director::services: 'bacula-dir'
+bacula::director::services: 'bacula_dir'
 bacula::storage::packages: [ 'bacula9-server' ]
-bacula::storage::services: 'bacula-sd'
+bacula::storage::services: 'bacula_sd'
 bacula::client::packages: [ 'bacula9-client' ]
-bacula::client::services: 'bacula-fd'
+bacula::client::services: 'bacula_fd'
 bacula::conf_dir: '/usr/local/etc/bacula'
 bacula::rundir: '/var/run'
 bacula::homedir: '/var/db/bacula'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The service names on FreeBSD have been renamed:

```
    "service bacula-fd ..."  to "service bacula_fd ..."
    "service bacula-dir ..." to "service bacula_dir ..."
    "service bacula-sd ..."  to "service bacula_sd ..."
```

Related upstream commit:
https://github.com/freebsd/freebsd-ports/commit/8636c2e7142ea93b5c23609c5f06f4e52aa0ad31

#### This Pull Request (PR) fixes the following issues
none