### PR TITLE
Allow passing a `Sensitive` as password to `Bacula::Director::Console`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1089,7 +1089,7 @@ Default value: `$bacula::conf_dir`
 
 ##### <a name="-bacula--director--console--password"></a>`password`
 
-Data type: `String[1]`
+Data type: `Bacula::Password`
 
 The password that must be supplied for a named Bacula Console to be authorized
 

--- a/manifests/director/console.pp
+++ b/manifests/director/console.pp
@@ -25,7 +25,7 @@
 #   }
 #
 define bacula::director::console (
-  String[1]              $password,
+  Bacula::Password       $password,
   String                 $conf_dir    = $bacula::conf_dir,
   String[1]              $catalogacl  = '*all*',
   Array[Bacula::Command] $commandacl  = ['list'],


### PR DESCRIPTION
The `Bacula::Director::Console` class has just been merged in #210.

I though I would rebase #190 on top of master after merging, but did not realized the work in this PR was already in master and so the PR was obsolete.

Rely on the custom data tye `Bacula::Password` for the password.
